### PR TITLE
Extra filters to read counting and some cleanup

### DIFF
--- a/scCNA/R/getCoverageTrack.R
+++ b/scCNA/R/getCoverageTrack.R
@@ -1,10 +1,9 @@
-getCoverageTrack <- function (bamPath, chr, starts, ends, CHRSTRING = "")
+getCoverageTrack <- function (bamPath, chr, starts, ends, CHRSTRING = "", isDuplicate=F, isSecondaryAlignment=F, isNotPassingQualityControls=T, isUnmappedQuery=T, mapqFilter=0)
 {
     require(Rsamtools)
     require(GenomicRanges)
-    sbp <- ScanBamParam(flag = scanBamFlag(isDuplicate = FALSE,isSecondaryAlignment=FALSE),
-    which = GRanges(paste0(CHRSTRING, chr), IRanges(starts,
-    ends)))
+    sbp <- ScanBamParam(flag = scanBamFlag(isDuplicate=isDuplicate, isSecondaryAlignment=isSecondaryAlignment, isNotPassingQualityControls=isNotPassingQualityControls, isUnmappedQuery=isUnmappedQuery),
+    which = GRanges(paste0(CHRSTRING, chr), IRanges(starts,ends)), mapqFilter=mapqFilter)
     coverageTrack <- countBam(bamPath, param = sbp)
     coverageTrack$records <- coverageTrack$records
     return(coverageTrack)

--- a/scCNA/R/getTrackForAll.R
+++ b/scCNA/R/getTrackForAll.R
@@ -3,8 +3,6 @@ function(bamfile,
                            window,
                            lSe=NULL,
                            lGCT=NULL,
-                           mappa=NULL,
-                           repli=NULL,
                            allchr=1:22,
                            sdNormalise=0,
                            segmentation_alpha=0.01,
@@ -30,18 +28,8 @@ function(bamfile,
     
     if(is.null(lGCT)) { print("get GC content"); lGCT <- lapply(allchr,function(chr) gcTrack(chr,lSe[[chr]]$starts,lSe[[chr]]$ends)) }
     ## ##################################################
-    if (!is.null(mappa)) {
-      print("correct for mappability")
-      lCTS <- smoothCoverageTrackAll(lCT,lSe,mappa)
-    }
-    
     print("correct for GC content")
     lCTS <- smoothCoverageTrackAll(lCT,lSe,lGCT)
-    
-    if (!is.null(repli)) {
-      print("correct for replication timing")
-      lCTS <- smoothCoverageTrackAll(lCT,lSe,repli)
-    }
     
     gc()
     ## ##################################################

--- a/scCNA/R/getTrackForAll.R
+++ b/scCNA/R/getTrackForAll.R
@@ -3,22 +3,46 @@ function(bamfile,
                            window,
                            lSe=NULL,
                            lGCT=NULL,
+                           mappa=NULL,
+                           repli=NULL,
                            allchr=1:22,
-                           sdNormalise=0)
+                           sdNormalise=0,
+                           segmentation_alpha=0.01,
+			   isDuplicate=F, 
+			   isSecondaryAlignment=F,
+			   isNotPassingQualityControls=T,
+			   isUnmappedQuery=T, 
+			   mapqFilter=0)
 {
-    print("get Start-End of segments")
-    if(is.null(lSe)) lSe <- lapply(allchr,function(chr) getStartsEnds(window,paste0(chr)))
+    
+    if(is.null(lSe)) { print("get Start-End of segments"); lSe <- lapply(allchr,function(chr) getStartsEnds(window,paste0(chr))) } 
     ## ##################################################
     print("get Coverage Track")
     lCT <- lapply(allchr, function(chr) getCoverageTrack(bamPath=bamfile,
                                                          chr=paste0(chr),
                                                          lSe[[chr]]$starts,
-                                                         lSe[[chr]]$ends))
-    print("get GC content")
-    if(is.null(lGCT)) lGCT <- lapply(allchr,function(chr) gcTrack(chr,lSe[[chr]]$starts,lSe[[chr]]$ends))
+                                                         lSe[[chr]]$ends,
+							 isDuplicate=isDuplicate, 
+							 isSecondaryAlignment=isSecondaryAlignment,
+							 isNotPassingQualityControls=isNotPassingQualityControls,
+							 isUnmappedQuery=isUnmappedQuery,
+							 mapqFilter=mapqFilter))
+    
+    if(is.null(lGCT)) { print("get GC content"); lGCT <- lapply(allchr,function(chr) gcTrack(chr,lSe[[chr]]$starts,lSe[[chr]]$ends)) }
     ## ##################################################
+    if (!is.null(mappa)) {
+      print("correct for mappability")
+      lCTS <- smoothCoverageTrackAll(lCT,lSe,mappa)
+    }
+    
     print("correct for GC content")
     lCTS <- smoothCoverageTrackAll(lCT,lSe,lGCT)
+    
+    if (!is.null(repli)) {
+      print("correct for replication timing")
+      lCTS <- smoothCoverageTrackAll(lCT,lSe,repli)
+    }
+    
     gc()
     ## ##################################################
     print("segment Tracks")
@@ -29,7 +53,8 @@ function(bamfile,
                                 chr=paste0(x),
                                 sd=sdNormalise,
                                 lSe[[x]]$starts,
-                                lSe[[x]]$ends)
+                                lSe[[x]]$ends,
+                                alpha=segmentation_alpha)
     })
     names(lSegs) <- paste0(1:length(lCT))
     tracks <- list(lCTS=lCTS,lSegs=lSegs)


### PR DESCRIPTION
getCoverageTrack now exports its filters and has been extended to contain a few more. isDuplicate and isSecondaryAlignment were already there, isNotPassingQualityControls, isUnmappedQuery and mapqFilter are new. Their defaults are set to what the previous version of scCNA would've done, so no functionality should change. I'd recommend however to by default set all flags to FALSE and set the mapqFilter to 37. Please note that the flags are in both getCoverageTrack and getTrackForAll.

Also changed in getTrackForAll is that some print statements have been moved. GC content correction is optional, but when it's not executed the print statement would still be executed. The print has been moved into the if statement such that the text only appears when the step is actually executed.

Finally, getTrackForAll now exports the segmentation_alpha parameter.