### PR TITLE
Added support for correction via control sample

### DIFF
--- a/scCNA/R/getTrackForAll.R
+++ b/scCNA/R/getTrackForAll.R
@@ -58,9 +58,9 @@ function(bamfile,
         norm = lCTSn[[i]]
         
         smoothed_tum = tum$smoothed
-        smoothed_nolog = 10^smoothed_tum
-        smoothed_nolog = 10^norm$smoothed
-        tum$smoothed_corrected_nolog = smoothed_nolog / smoothed_nolog
+        tum_smoothed_nolog = 10^smoothed_tum
+        norm_smoothed_nolog = 10^norm$smoothed
+        tum$smoothed_corrected_nolog = tum_smoothed_nolog / norm_smoothed_nolog
         tum$smoothed = log10(tum$smoothed_corrected_nolog)
         tum$smoothed_tumour = smoothed_tum
         tum$records_normal = norm$records

--- a/scCNA/R/getTrackForAll.R
+++ b/scCNA/R/getTrackForAll.R
@@ -57,10 +57,14 @@ function(bamfile,
         tum = lCTS[[i]]
         norm = lCTSn[[i]]
         
-        tum$smoothed_nolog = 10^tum$smoothed
-        norm$smoothed_nolog = 10^norm$smoothed
-        tum$smoothed_corrected_nolog = tum$smoothed_nolog / norm$smoothed_nolog
+        smoothed_tum = tum$smoothed
+        smoothed_nolog = 10^smoothed_tum
+        smoothed_nolog = 10^norm$smoothed
+        tum$smoothed_corrected_nolog = smoothed_nolog / smoothed_nolog
         tum$smoothed = log10(tum$smoothed_corrected_nolog)
+        tum$smoothed_tumour = smoothed_tum
+        tum$records_normal = norm$records
+        tum$smoothed_normal = norm$records
         lCTS[[i]] = tum
       }
     }


### PR DESCRIPTION
This update adds the option to provide a normal/control sample, via which the signal will be corrected (i.e. allowing for tumour-normal or sample-control runs).

The control is GC corrected separately in the same manner as the tumour. In the future it may be advantageous to change this to first correct tumour with control and then correct GC content bias.

Have not made any further changes as the discussed upcoming changed GC content correction code.